### PR TITLE
docs(datadog): add examples/minimal/config.yaml

### DIFF
--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -1,0 +1,16 @@
+# Minimal config exercising workflow-plugin-datadog.
+# Schema-validate with: wfctl validate --skip-unknown-types examples/minimal/config.yaml
+
+version: 1
+
+modules:
+  - name: datadog-provider
+    type: datadog.provider
+    config: {}
+
+workflows:
+  pipeline:
+    steps:
+      - name: example
+        type: step.datadog_metric_submit
+        config: {}


### PR DESCRIPTION
Closes the P2-tier examples gap from the 2026-05-19 QoL sweep (workflow#714).