### PR TITLE
ci: bump wfctl pin v0.63.1 → v0.63.2 (workflow#765 implementation actually shipped)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Configure Go private modules
         run: git config --global url."https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
 
-      - name: Install wfctl v0.63.1
+      - name: Install wfctl v0.63.2
         run: |
           mkdir -p "${RUNNER_TEMP}/wfctl-bin"
           curl -sSfL -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -o "${RUNNER_TEMP}/wfctl-bin/wfctl" \
-            "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.1/wfctl-linux-amd64"
+            "https://github.com/GoCodeAlone/workflow/releases/download/v0.63.2/wfctl-linux-amd64"
           chmod +x "${RUNNER_TEMP}/wfctl-bin/wfctl"
       - name: Validate plugin contract for publish (pre-build)
         run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} ."


### PR DESCRIPTION
v0.63.1 was tagged at a commit that did NOT include the verify-capabilities subcommand (PR #766 squash-merge ran against stale remote ref; implementation commits stayed local). v0.63.2 (tagged at PR #769 merge) ships the actual subcommand. This PR bumps the release.yml pin so the new step ('wfctl plugin verify-capabilities --binary ... .') resolves to a binary that has the subcommand.