### PR TITLE
chore: advertise required_secrets[] (DATADOG_API_KEY, DATADOG_APP_KEY)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5679 +1,5693 @@
 {
-    "name": "workflow-plugin-datadog",
-    "version": "0.1.3",
-    "description": "Datadog monitoring and observability plugin",
-    "author": "GoCodeAlone",
-    "license": "MIT",
-    "type": "external",
-    "tier": "community",
-    "private": false,
-    "minEngineVersion": "0.51.7",
-    "keywords": [
-        "datadog",
-        "monitoring",
-        "observability",
-        "metrics",
-        "logs",
-        "apm"
-    ],
-    "homepage": "https://github.com/GoCodeAlone/workflow-plugin-datadog",
-    "repository": "https://github.com/GoCodeAlone/workflow-plugin-datadog",
-    "moduleTypes": [
-        "datadog.provider"
-    ],
-    "stepTypes": [
-        "step.datadog_metric_submit",
-        "step.datadog_metric_query",
-        "step.datadog_metric_query_scalar",
-        "step.datadog_metric_metadata_get",
-        "step.datadog_metric_metadata_update",
-        "step.datadog_metric_list_active",
-        "step.datadog_metric_tag_config_create",
-        "step.datadog_metric_tag_config_update",
-        "step.datadog_metric_tag_config_delete",
-        "step.datadog_metric_tag_config_list",
-        "step.datadog_event_create",
-        "step.datadog_event_get",
-        "step.datadog_event_list",
-        "step.datadog_event_search",
-        "step.datadog_monitor_create",
-        "step.datadog_monitor_get",
-        "step.datadog_monitor_update",
-        "step.datadog_monitor_delete",
-        "step.datadog_monitor_list",
-        "step.datadog_monitor_search",
-        "step.datadog_monitor_validate",
-        "step.datadog_dashboard_create",
-        "step.datadog_dashboard_get",
-        "step.datadog_dashboard_update",
-        "step.datadog_dashboard_delete",
-        "step.datadog_dashboard_list",
-        "step.datadog_log_submit",
-        "step.datadog_log_search",
-        "step.datadog_log_aggregate",
-        "step.datadog_log_archive_create",
-        "step.datadog_log_archive_list",
-        "step.datadog_log_archive_delete",
-        "step.datadog_log_pipeline_create",
-        "step.datadog_log_pipeline_list",
-        "step.datadog_log_pipeline_delete",
-        "step.datadog_synthetics_test_create",
-        "step.datadog_synthetics_test_get",
-        "step.datadog_synthetics_test_update",
-        "step.datadog_synthetics_test_delete",
-        "step.datadog_synthetics_test_list",
-        "step.datadog_synthetics_test_trigger",
-        "step.datadog_synthetics_results_get",
-        "step.datadog_synthetics_global_var_create",
-        "step.datadog_synthetics_global_var_list",
-        "step.datadog_synthetics_global_var_delete",
-        "step.datadog_slo_create",
-        "step.datadog_slo_get",
-        "step.datadog_slo_update",
-        "step.datadog_slo_delete",
-        "step.datadog_slo_list",
-        "step.datadog_slo_search",
-        "step.datadog_slo_history_get",
-        "step.datadog_downtime_create",
-        "step.datadog_downtime_get",
-        "step.datadog_downtime_update",
-        "step.datadog_downtime_cancel",
-        "step.datadog_downtime_list",
-        "step.datadog_incident_create",
-        "step.datadog_incident_get",
-        "step.datadog_incident_update",
-        "step.datadog_incident_delete",
-        "step.datadog_incident_list",
-        "step.datadog_incident_todo_create",
-        "step.datadog_incident_todo_update",
-        "step.datadog_incident_todo_delete",
-        "step.datadog_security_rule_create",
-        "step.datadog_security_rule_get",
-        "step.datadog_security_rule_update",
-        "step.datadog_security_rule_delete",
-        "step.datadog_security_rule_list",
-        "step.datadog_security_signal_list",
-        "step.datadog_security_signal_state_update",
-        "step.datadog_user_create",
-        "step.datadog_user_get",
-        "step.datadog_user_update",
-        "step.datadog_user_disable",
-        "step.datadog_user_list",
-        "step.datadog_user_invite",
-        "step.datadog_role_create",
-        "step.datadog_role_get",
-        "step.datadog_role_update",
-        "step.datadog_role_delete",
-        "step.datadog_role_list",
-        "step.datadog_role_permission_add",
-        "step.datadog_role_permission_remove",
-        "step.datadog_team_create",
-        "step.datadog_team_get",
-        "step.datadog_team_update",
-        "step.datadog_team_delete",
-        "step.datadog_team_list",
-        "step.datadog_team_member_add",
-        "step.datadog_team_member_remove",
-        "step.datadog_api_key_create",
-        "step.datadog_api_key_get",
-        "step.datadog_api_key_update",
-        "step.datadog_api_key_delete",
-        "step.datadog_api_key_list",
-        "step.datadog_app_key_create",
-        "step.datadog_app_key_list",
-        "step.datadog_app_key_delete",
-        "step.datadog_notebook_create",
-        "step.datadog_notebook_get",
-        "step.datadog_notebook_update",
-        "step.datadog_notebook_delete",
-        "step.datadog_notebook_list",
-        "step.datadog_host_list",
-        "step.datadog_host_mute",
-        "step.datadog_host_unmute",
-        "step.datadog_host_totals_get",
-        "step.datadog_tags_get",
-        "step.datadog_tags_update",
-        "step.datadog_tags_delete",
-        "step.datadog_tags_list",
-        "step.datadog_service_definition_upsert",
-        "step.datadog_service_definition_get",
-        "step.datadog_service_definition_delete",
-        "step.datadog_service_definition_list",
-        "step.datadog_apm_retention_filter_create",
-        "step.datadog_apm_retention_filter_update",
-        "step.datadog_apm_retention_filter_delete",
-        "step.datadog_apm_retention_filter_list",
-        "step.datadog_span_search",
-        "step.datadog_span_aggregate",
-        "step.datadog_audit_log_search",
-        "step.datadog_audit_log_list"
-    ],
-    "triggerTypes": [],
-    "stepSchemas": [
-        {
-            "description": "Submit a metric to Datadog",
-            "type": "step.datadog_metric_submit",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "required": true,
-                    "description": "Metric name",
-                    "label": "Metric"
-                },
-                {
-                    "key": "value",
-                    "type": "number",
-                    "required": false,
-                    "description": "Metric value",
-                    "label": "Value"
-                },
-                {
-                    "key": "type",
-                    "type": "select",
-                    "required": false,
-                    "options": [
-                        "count",
-                        "rate",
-                        "gauge"
-                    ],
-                    "description": "Metric type",
-                    "label": "Type"
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "required": false,
-                    "description": "Tags",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "submitted",
-                    "type": "boolean",
-                    "description": "Whether the operation was successfully submitted."
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "description": "The metric name."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Query metrics from Datadog",
-            "type": "step.datadog_metric_query",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": true,
-                    "description": "Metrics query",
-                    "label": "Query"
-                },
-                {
-                    "key": "from",
-                    "type": "number",
-                    "required": false,
-                    "description": "Start time (epoch seconds)",
-                    "label": "From"
-                },
-                {
-                    "key": "to",
-                    "type": "number",
-                    "required": false,
-                    "description": "End time (epoch seconds)",
-                    "label": "To"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "series",
-                    "type": "array",
-                    "description": "Array of metric time series data points."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Query scalar metrics from Datadog",
-            "type": "step.datadog_metric_query_scalar",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": true,
-                    "description": "Scalar query",
-                    "label": "Query"
-                },
-                {
-                    "key": "from",
-                    "type": "number",
-                    "required": false,
-                    "description": "Start time",
-                    "label": "From"
-                },
-                {
-                    "key": "to",
-                    "type": "number",
-                    "required": false,
-                    "description": "End time",
-                    "label": "To"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "queried",
-                    "type": "boolean",
-                    "description": "Whether the query was successfully executed."
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "description": "The query used."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get metric metadata",
-            "type": "step.datadog_metric_metadata_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "required": true,
-                    "description": "Metric name",
-                    "label": "Metric"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "type",
-                    "type": "string",
-                    "description": "The type of the resource."
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "description": "The description of the resource."
-                },
-                {
-                    "key": "unit",
-                    "type": "string",
-                    "description": "The unit of measurement."
-                },
-                {
-                    "key": "short_name",
-                    "type": "string",
-                    "description": "The short name or identifier."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update metric metadata",
-            "type": "step.datadog_metric_metadata_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "required": true,
-                    "description": "Metric name",
-                    "label": "Metric"
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "required": false,
-                    "description": "Description",
-                    "label": "Description"
-                },
-                {
-                    "key": "unit",
-                    "type": "string",
-                    "required": false,
-                    "description": "Unit",
-                    "label": "Unit"
-                },
-                {
-                    "key": "type",
-                    "type": "string",
-                    "required": false,
-                    "description": "Type",
-                    "label": "Type"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "type",
-                    "type": "string",
-                    "description": "The type of the resource."
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "description": "The description of the resource."
-                },
-                {
-                    "key": "unit",
-                    "type": "string",
-                    "description": "The unit of measurement."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List active metrics",
-            "type": "step.datadog_metric_list_active",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "from",
-                    "type": "number",
-                    "required": false,
-                    "description": "Start time (epoch seconds)",
-                    "label": "From"
-                },
-                {
-                    "key": "host",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter by host",
-                    "label": "Host"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "metrics",
-                    "type": "array",
-                    "description": "The metrics of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create metric tag configuration",
-            "type": "step.datadog_metric_tag_config_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "required": true,
-                    "description": "Metric name",
-                    "label": "Metric"
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "required": false,
-                    "description": "Tags",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "created",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully created."
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "description": "The metric name."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update metric tag configuration",
-            "type": "step.datadog_metric_tag_config_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "required": true,
-                    "description": "Metric name",
-                    "label": "Metric"
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "required": false,
-                    "description": "Tags",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "description": "The metric name."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete metric tag configuration",
-            "type": "step.datadog_metric_tag_config_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "required": true,
-                    "description": "Metric name",
-                    "label": "Metric"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the metric tag configuration was successfully deleted."
-                },
-                {
-                    "key": "metric",
-                    "type": "string",
-                    "description": "The metric name."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List metric tag configurations",
-            "type": "step.datadog_metric_tag_config_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "configurations",
-                    "type": "array",
-                    "description": "The configurations of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog event",
-            "type": "step.datadog_event_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "required": true,
-                    "description": "Event title",
-                    "label": "Title"
-                },
-                {
-                    "key": "text",
-                    "type": "string",
-                    "required": false,
-                    "description": "Event text",
-                    "label": "Text"
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "required": false,
-                    "description": "Tags",
-                    "label": "Tags"
-                },
-                {
-                    "key": "host",
-                    "type": "string",
-                    "required": false,
-                    "description": "Host name",
-                    "label": "Host"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "description": "The title of the resource."
-                },
-                {
-                    "key": "status",
-                    "type": "string",
-                    "description": "The current status of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog event",
-            "type": "step.datadog_event_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "event_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Event ID",
-                    "label": "Event Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "found",
-                    "type": "boolean",
-                    "description": "Whether the event was found."
-                },
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "description": "The title of the resource."
-                },
-                {
-                    "key": "text",
-                    "type": "string",
-                    "description": "The text of the operation result."
-                },
-                {
-                    "key": "host",
-                    "type": "string",
-                    "description": "The host of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog events",
-            "type": "step.datadog_event_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "start",
-                    "type": "number",
-                    "required": false,
-                    "description": "Start time",
-                    "label": "Start"
-                },
-                {
-                    "key": "end",
-                    "type": "number",
-                    "required": false,
-                    "description": "End time",
-                    "label": "End"
-                },
-                {
-                    "key": "tags",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter by tags",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "events",
-                    "type": "array",
-                    "description": "List of events."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Search Datadog events",
-            "type": "step.datadog_event_search",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "start",
-                    "type": "number",
-                    "required": false,
-                    "description": "Start time",
-                    "label": "Start"
-                },
-                {
-                    "key": "end",
-                    "type": "number",
-                    "required": false,
-                    "description": "End time",
-                    "label": "End"
-                },
-                {
-                    "key": "tags",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter by tags",
-                    "label": "Tags"
-                },
-                {
-                    "key": "sources",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter by sources",
-                    "label": "Sources"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "events",
-                    "type": "array",
-                    "description": "List of events."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog monitor",
-            "type": "step.datadog_monitor_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Monitor name",
-                    "label": "Name"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": true,
-                    "description": "Monitor query",
-                    "label": "Query"
-                },
-                {
-                    "key": "type",
-                    "type": "select",
-                    "required": false,
-                    "options": [
-                        "metric alert",
-                        "service check",
-                        "event alert",
-                        "log alert",
-                        "query alert"
-                    ],
-                    "description": "Monitor type",
-                    "label": "Type"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": false,
-                    "description": "Notification message",
-                    "label": "Message"
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "required": false,
-                    "description": "Tags",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog monitor",
-            "type": "step.datadog_monitor_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "monitor_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Monitor ID",
-                    "label": "Monitor Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "description": "The query used."
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "description": "The message content."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog monitor",
-            "type": "step.datadog_monitor_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "monitor_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Monitor ID",
-                    "label": "Monitor Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "Monitor name",
-                    "label": "Name"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Monitor query",
-                    "label": "Query"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": false,
-                    "description": "Notification message",
-                    "label": "Message"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog monitor",
-            "type": "step.datadog_monitor_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "monitor_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Monitor ID",
-                    "label": "Monitor Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog monitors",
-            "type": "step.datadog_monitor_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "tags",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter by tags",
-                    "label": "Tags"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter by name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "monitors",
-                    "type": "array",
-                    "description": "List of monitors."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Search Datadog monitors",
-            "type": "step.datadog_monitor_search",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Search query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "monitors",
-                    "type": "array",
-                    "description": "List of monitors."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Validate a Datadog monitor query",
-            "type": "step.datadog_monitor_validate",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": true,
-                    "description": "Monitor query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "valid",
-                    "type": "boolean",
-                    "description": "Whether the monitor configuration is valid."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog dashboard",
-            "type": "step.datadog_dashboard_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "required": true,
-                    "description": "Dashboard title",
-                    "label": "Title"
-                },
-                {
-                    "key": "layout_type",
-                    "type": "select",
-                    "required": false,
-                    "options": [
-                        "ordered",
-                        "free"
-                    ],
-                    "description": "Layout type",
-                    "label": "Layout Type"
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "required": false,
-                    "description": "Description",
-                    "label": "Description"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "description": "The title of the resource."
-                },
-                {
-                    "key": "url",
-                    "type": "string",
-                    "description": "The URL of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog dashboard",
-            "type": "step.datadog_dashboard_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "dashboard_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Dashboard ID",
-                    "label": "Dashboard Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "description": "The title of the resource."
-                },
-                {
-                    "key": "url",
-                    "type": "string",
-                    "description": "The URL of the resource."
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "description": "The description of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog dashboard",
-            "type": "step.datadog_dashboard_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "dashboard_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Dashboard ID",
-                    "label": "Dashboard Id"
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "required": false,
-                    "description": "Dashboard title. Defaults to \"Updated Dashboard\" when not provided.",
-                    "label": "Title"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "description": "The title of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog dashboard",
-            "type": "step.datadog_dashboard_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "dashboard_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Dashboard ID",
-                    "label": "Dashboard Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog dashboards",
-            "type": "step.datadog_dashboard_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "dashboards",
-                    "type": "array",
-                    "description": "List of dashboards."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Submit a log to Datadog",
-            "type": "step.datadog_log_submit",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": true,
-                    "description": "Log message",
-                    "label": "Message"
-                },
-                {
-                    "key": "service",
-                    "type": "string",
-                    "required": false,
-                    "description": "Service name",
-                    "label": "Service"
-                },
-                {
-                    "key": "source",
-                    "type": "string",
-                    "required": false,
-                    "description": "Log source",
-                    "label": "Source"
-                },
-                {
-                    "key": "host",
-                    "type": "string",
-                    "required": false,
-                    "description": "Host name",
-                    "label": "Host"
-                },
-                {
-                    "key": "tags",
-                    "type": "string",
-                    "required": false,
-                    "description": "Tags",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "submitted",
-                    "type": "boolean",
-                    "description": "Whether the operation was successfully submitted."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Search Datadog logs",
-            "type": "step.datadog_log_search",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Search query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "logs",
-                    "type": "array",
-                    "description": "List of log entries."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Aggregate Datadog logs",
-            "type": "step.datadog_log_aggregate",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Aggregation query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "buckets",
-                    "type": "array",
-                    "description": "The buckets of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a log archive",
-            "type": "step.datadog_log_archive_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Archive name",
-                    "label": "Name"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter query",
-                    "label": "Query"
-                },
-                {
-                    "key": "bucket",
-                    "type": "string",
-                    "required": false,
-                    "description": "S3 bucket name. Defaults to \"my-bucket\" when not provided, which will fail with a real Datadog API call.",
-                    "label": "Bucket"
-                },
-                {
-                    "key": "path",
-                    "type": "string",
-                    "required": false,
-                    "description": "Archive path",
-                    "label": "Path"
-                },
-                {
-                    "key": "role_arn",
-                    "type": "string",
-                    "required": false,
-                    "description": "IAM role name used by the Datadog-AWS S3 integration (not an ARN). Corresponds to the RoleName field in the Datadog API.",
-                    "label": "Role Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List log archives",
-            "type": "step.datadog_log_archive_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "archives",
-                    "type": "array",
-                    "description": "The archives of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a log archive",
-            "type": "step.datadog_log_archive_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "archive_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Archive ID",
-                    "label": "Archive Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a log pipeline",
-            "type": "step.datadog_log_pipeline_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Pipeline name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List log pipelines",
-            "type": "step.datadog_log_pipeline_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "pipelines",
-                    "type": "array",
-                    "description": "The pipelines of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a log pipeline",
-            "type": "step.datadog_log_pipeline_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "pipeline_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Pipeline ID",
-                    "label": "Pipeline Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a synthetic test",
-            "type": "step.datadog_synthetics_test_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Test name",
-                    "label": "Name"
-                },
-                {
-                    "key": "url",
-                    "type": "string",
-                    "required": false,
-                    "description": "Test URL. Defaults to \"https://example.com\" when not provided.",
-                    "label": "Url"
-                },
-                {
-                    "key": "locations",
-                    "type": "array",
-                    "required": false,
-                    "description": "Test locations. Defaults to \"aws:us-east-1\" when not provided.",
-                    "label": "Locations"
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "required": false,
-                    "description": "Tags",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "description": "The public id of the operation result."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a synthetic test",
-            "type": "step.datadog_synthetics_test_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Test public ID",
-                    "label": "Public Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "description": "The public id of the operation result."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a synthetic test",
-            "type": "step.datadog_synthetics_test_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Test public ID",
-                    "label": "Public Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "Test name",
-                    "label": "Name"
-                },
-                {
-                    "key": "url",
-                    "type": "string",
-                    "required": false,
-                    "description": "Test URL. Defaults to \"https://example.com\" when not provided, which will overwrite the existing URL.",
-                    "label": "Url"
-                },
-                {
-                    "key": "locations",
-                    "type": "array",
-                    "required": false,
-                    "description": "Test locations. Defaults to \"aws:us-east-1\" when not provided, which will overwrite the existing locations.",
-                    "label": "Locations"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "description": "The public id of the operation result."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete synthetic tests",
-            "type": "step.datadog_synthetics_test_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "public_ids",
-                    "type": "array",
-                    "required": false,
-                    "description": "List of public IDs to delete. At least one of public_ids or public_id is required.",
-                    "label": "Public Ids"
-                },
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "required": false,
-                    "description": "Single public ID to delete. At least one of public_id or public_ids is required.",
-                    "label": "Public Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "array",
-                    "description": "List of deleted public IDs."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List synthetic tests",
-            "type": "step.datadog_synthetics_test_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "tests",
-                    "type": "array",
-                    "description": "List of synthetic tests."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Trigger synthetic tests",
-            "type": "step.datadog_synthetics_test_trigger",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "public_ids",
-                    "type": "array",
-                    "required": false,
-                    "description": "List of public IDs to trigger. At least one of public_ids or public_id is required.",
-                    "label": "Public Ids"
-                },
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "required": false,
-                    "description": "Single public ID to trigger. At least one of public_id or public_ids is required.",
-                    "label": "Public Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "results",
-                    "type": "array",
-                    "description": "List of results."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get synthetic test results",
-            "type": "step.datadog_synthetics_results_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "public_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Test public ID",
-                    "label": "Public Id"
-                },
-                {
-                    "key": "result_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Result ID",
-                    "label": "Result Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "result_id",
-                    "type": "string",
-                    "description": "The result id of the operation result."
-                },
-                {
-                    "key": "status",
-                    "type": "number",
-                    "description": "The current status of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a synthetic global variable",
-            "type": "step.datadog_synthetics_global_var_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Variable name",
-                    "label": "Name"
-                },
-                {
-                    "key": "value",
-                    "type": "string",
-                    "required": false,
-                    "description": "Variable value",
-                    "label": "Value"
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "required": false,
-                    "description": "Description",
-                    "label": "Description"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List synthetic global variables",
-            "type": "step.datadog_synthetics_global_var_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "variables",
-                    "type": "array",
-                    "description": "The variables of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a synthetic global variable",
-            "type": "step.datadog_synthetics_global_var_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "variable_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Variable ID",
-                    "label": "Variable Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Service Level Objective",
-            "type": "step.datadog_slo_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "SLO name",
-                    "label": "Name"
-                },
-                {
-                    "key": "type",
-                    "type": "select",
-                    "required": false,
-                    "options": [
-                        "metric",
-                        "monitor"
-                    ],
-                    "description": "SLO type",
-                    "label": "Type"
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "required": false,
-                    "description": "Description",
-                    "label": "Description"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Service Level Objective",
-            "type": "step.datadog_slo_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "slo_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "SLO ID",
-                    "label": "Slo Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "found",
-                    "type": "boolean",
-                    "description": "The found of the operation result."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Service Level Objective",
-            "type": "step.datadog_slo_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "slo_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "SLO ID",
-                    "label": "Slo Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "SLO name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Service Level Objective",
-            "type": "step.datadog_slo_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "slo_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "SLO ID",
-                    "label": "Slo Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Service Level Objectives",
-            "type": "step.datadog_slo_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "slos",
-                    "type": "array",
-                    "description": "List of SLOs."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Search Service Level Objectives",
-            "type": "step.datadog_slo_search",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Search query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "slos",
-                    "type": "array",
-                    "description": "List of SLOs."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get SLO history",
-            "type": "step.datadog_slo_history_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "slo_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "SLO ID",
-                    "label": "Slo Id"
-                },
-                {
-                    "key": "from",
-                    "type": "number",
-                    "required": false,
-                    "description": "Start time (epoch seconds)",
-                    "label": "From"
-                },
-                {
-                    "key": "to",
-                    "type": "number",
-                    "required": false,
-                    "description": "End time (epoch seconds)",
-                    "label": "To"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "slo_id",
-                    "type": "string",
-                    "description": "The slo id of the operation result."
-                },
-                {
-                    "key": "from",
-                    "type": "number",
-                    "description": "The from of the operation result."
-                },
-                {
-                    "key": "to",
-                    "type": "number",
-                    "description": "The to of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog downtime",
-            "type": "step.datadog_downtime_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "scope",
-                    "type": "string",
-                    "required": false,
-                    "description": "Downtime scope",
-                    "label": "Scope"
-                },
-                {
-                    "key": "start",
-                    "type": "number",
-                    "required": false,
-                    "description": "Start time (epoch seconds)",
-                    "label": "Start"
-                },
-                {
-                    "key": "end",
-                    "type": "number",
-                    "required": false,
-                    "description": "End time (epoch seconds)",
-                    "label": "End"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": false,
-                    "description": "Message",
-                    "label": "Message"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "scope",
-                    "type": "array",
-                    "description": "The scope of the operation result."
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "description": "The message content."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog downtime",
-            "type": "step.datadog_downtime_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "downtime_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Downtime ID",
-                    "label": "Downtime Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "scope",
-                    "type": "array",
-                    "description": "The scope of the operation result."
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "description": "The message content."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog downtime",
-            "type": "step.datadog_downtime_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "downtime_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Downtime ID",
-                    "label": "Downtime Id"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": false,
-                    "description": "Message",
-                    "label": "Message"
-                },
-                {
-                    "key": "scope",
-                    "type": "string",
-                    "required": false,
-                    "description": "Scope",
-                    "label": "Scope"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Cancel a Datadog downtime",
-            "type": "step.datadog_downtime_cancel",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "downtime_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Downtime ID",
-                    "label": "Downtime Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "cancelled",
-                    "type": "boolean",
-                    "description": "The cancelled of the operation result."
-                },
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog downtimes",
-            "type": "step.datadog_downtime_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "current_only",
-                    "type": "boolean",
-                    "required": false,
-                    "description": "Return only current downtimes",
-                    "label": "Current Only"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "downtimes",
-                    "type": "array",
-                    "description": "List of downtimes."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog incident",
-            "type": "step.datadog_incident_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "required": true,
-                    "description": "Incident title",
-                    "label": "Title"
-                },
-                {
-                    "key": "customer_impacted",
-                    "type": "boolean",
-                    "required": false,
-                    "description": "Customer impacted",
-                    "label": "Customer Impacted"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "description": "The title of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog incident",
-            "type": "step.datadog_incident_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "incident_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Incident ID",
-                    "label": "Incident Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "description": "The title of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog incident",
-            "type": "step.datadog_incident_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "incident_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Incident ID",
-                    "label": "Incident Id"
-                },
-                {
-                    "key": "title",
-                    "type": "string",
-                    "required": false,
-                    "description": "Incident title",
-                    "label": "Title"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog incident",
-            "type": "step.datadog_incident_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "incident_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Incident ID",
-                    "label": "Incident Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog incidents",
-            "type": "step.datadog_incident_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "incidents",
-                    "type": "array",
-                    "description": "List of incidents."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create an incident todo",
-            "type": "step.datadog_incident_todo_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "incident_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Incident ID",
-                    "label": "Incident Id"
-                },
-                {
-                    "key": "content",
-                    "type": "string",
-                    "required": true,
-                    "description": "Todo content",
-                    "label": "Content"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "incident_id",
-                    "type": "string",
-                    "description": "The incident id of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update an incident todo",
-            "type": "step.datadog_incident_todo_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "incident_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Incident ID",
-                    "label": "Incident Id"
-                },
-                {
-                    "key": "todo_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Todo ID",
-                    "label": "Todo Id"
-                },
-                {
-                    "key": "content",
-                    "type": "string",
-                    "required": false,
-                    "description": "Todo content",
-                    "label": "Content"
-                },
-                {
-                    "key": "completed",
-                    "type": "boolean",
-                    "required": false,
-                    "description": "Set to true to mark the todo as completed. Setting false has no effect.",
-                    "label": "Completed"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete an incident todo",
-            "type": "step.datadog_incident_todo_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "incident_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Incident ID",
-                    "label": "Incident Id"
-                },
-                {
-                    "key": "todo_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Todo ID",
-                    "label": "Todo Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a security monitoring rule",
-            "type": "step.datadog_security_rule_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Rule name",
-                    "label": "Name"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": false,
-                    "description": "Rule message",
-                    "label": "Message"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a security monitoring rule",
-            "type": "step.datadog_security_rule_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "rule_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Rule ID",
-                    "label": "Rule Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a security monitoring rule",
-            "type": "step.datadog_security_rule_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "rule_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Rule ID",
-                    "label": "Rule Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Rule name",
-                    "label": "Name"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": false,
-                    "description": "Rule message",
-                    "label": "Message"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a security monitoring rule",
-            "type": "step.datadog_security_rule_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "rule_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Rule ID",
-                    "label": "Rule Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List security monitoring rules",
-            "type": "step.datadog_security_rule_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "rules",
-                    "type": "array",
-                    "description": "List of security rules."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List security signals",
-            "type": "step.datadog_security_signal_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "signals",
-                    "type": "array",
-                    "description": "List of security signals."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update security signal state",
-            "type": "step.datadog_security_signal_state_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "signal_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Signal ID",
-                    "label": "Signal Id"
-                },
-                {
-                    "key": "state",
-                    "type": "select",
-                    "required": false,
-                    "options": [
-                        "open",
-                        "archived",
-                        "under_review"
-                    ],
-                    "description": "Signal state",
-                    "label": "State"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "signal_id",
-                    "type": "string",
-                    "description": "The signal id of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog user",
-            "type": "step.datadog_user_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "email",
-                    "type": "string",
-                    "required": true,
-                    "description": "User email",
-                    "label": "Email"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "User name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "email",
-                    "type": "string",
-                    "description": "The email address."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog user",
-            "type": "step.datadog_user_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "user_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "User ID",
-                    "label": "User Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "email",
-                    "type": "string",
-                    "description": "The email address."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog user",
-            "type": "step.datadog_user_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "user_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "User ID",
-                    "label": "User Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "User name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Disable a Datadog user",
-            "type": "step.datadog_user_disable",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "user_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "User ID",
-                    "label": "User Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "disabled",
-                    "type": "boolean",
-                    "description": "The disabled of the operation result."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog users",
-            "type": "step.datadog_user_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "users",
-                    "type": "array",
-                    "description": "List of users."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Invite a Datadog user",
-            "type": "step.datadog_user_invite",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "user_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "User ID",
-                    "label": "User Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "invitations",
-                    "type": "array",
-                    "description": "The invitations of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog role",
-            "type": "step.datadog_role_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Role name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog role",
-            "type": "step.datadog_role_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "role_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Role ID",
-                    "label": "Role Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog role",
-            "type": "step.datadog_role_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "role_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Role ID",
-                    "label": "Role Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Role name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog role",
-            "type": "step.datadog_role_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "role_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Role ID",
-                    "label": "Role Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog roles",
-            "type": "step.datadog_role_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "roles",
-                    "type": "array",
-                    "description": "List of roles."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Add a permission to a role",
-            "type": "step.datadog_role_permission_add",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "role_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Role ID",
-                    "label": "Role Id"
-                },
-                {
-                    "key": "permission_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Permission ID",
-                    "label": "Permission Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "added",
-                    "type": "boolean",
-                    "description": "The added of the operation result."
-                },
-                {
-                    "key": "permission_count",
-                    "type": "number",
-                    "description": "The permission count of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Remove a permission from a role",
-            "type": "step.datadog_role_permission_remove",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "role_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Role ID",
-                    "label": "Role Id"
-                },
-                {
-                    "key": "permission_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Permission ID",
-                    "label": "Permission Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "removed",
-                    "type": "boolean",
-                    "description": "The removed of the operation result."
-                },
-                {
-                    "key": "role_id",
-                    "type": "string",
-                    "description": "The role id of the operation result."
-                },
-                {
-                    "key": "permission_id",
-                    "type": "string",
-                    "description": "The permission id of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog team",
-            "type": "step.datadog_team_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Team name",
-                    "label": "Name"
-                },
-                {
-                    "key": "handle",
-                    "type": "string",
-                    "required": true,
-                    "description": "Team handle",
-                    "label": "Handle"
-                },
-                {
-                    "key": "description",
-                    "type": "string",
-                    "required": false,
-                    "description": "Description",
-                    "label": "Description"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "handle",
-                    "type": "string",
-                    "description": "The team handle."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog team",
-            "type": "step.datadog_team_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "team_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Team ID",
-                    "label": "Team Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog team",
-            "type": "step.datadog_team_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "team_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Team ID",
-                    "label": "Team Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "Team name",
-                    "label": "Name"
-                },
-                {
-                    "key": "handle",
-                    "type": "string",
-                    "required": false,
-                    "description": "Team handle. Defaults to team_id when not provided, which may overwrite an existing handle.",
-                    "label": "Handle"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog team",
-            "type": "step.datadog_team_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "team_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Team ID",
-                    "label": "Team Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog teams",
-            "type": "step.datadog_team_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "teams",
-                    "type": "array",
-                    "description": "List of teams."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Add a member to a team",
-            "type": "step.datadog_team_member_add",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "team_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Team ID",
-                    "label": "Team Id"
-                },
-                {
-                    "key": "user_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "User ID",
-                    "label": "User Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "added",
-                    "type": "boolean",
-                    "description": "The added of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Remove a member from a team",
-            "type": "step.datadog_team_member_remove",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "team_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Team ID",
-                    "label": "Team Id"
-                },
-                {
-                    "key": "user_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "User ID",
-                    "label": "User Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "removed",
-                    "type": "boolean",
-                    "description": "The removed of the operation result."
-                },
-                {
-                    "key": "team_id",
-                    "type": "string",
-                    "description": "The team id of the operation result."
-                },
-                {
-                    "key": "user_id",
-                    "type": "string",
-                    "description": "The user id of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog API key",
-            "type": "step.datadog_api_key_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Key name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog API key",
-            "type": "step.datadog_api_key_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "key_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Key ID",
-                    "label": "Key Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog API key",
-            "type": "step.datadog_api_key_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "key_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Key ID",
-                    "label": "Key Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "Key name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog API key",
-            "type": "step.datadog_api_key_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "key_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Key ID",
-                    "label": "Key Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog API keys",
-            "type": "step.datadog_api_key_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "keys",
-                    "type": "array",
-                    "description": "List of API/application keys."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog application key",
-            "type": "step.datadog_app_key_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Key name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog application keys",
-            "type": "step.datadog_app_key_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "keys",
-                    "type": "array",
-                    "description": "List of API/application keys."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog application key",
-            "type": "step.datadog_app_key_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "key_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Key ID",
-                    "label": "Key Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create a Datadog notebook",
-            "type": "step.datadog_notebook_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Notebook name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a Datadog notebook",
-            "type": "step.datadog_notebook_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "notebook_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Notebook ID",
-                    "label": "Notebook Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update a Datadog notebook",
-            "type": "step.datadog_notebook_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "notebook_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Notebook ID",
-                    "label": "Notebook Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": false,
-                    "description": "Notebook name",
-                    "label": "Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a Datadog notebook",
-            "type": "step.datadog_notebook_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "notebook_id",
-                    "type": "number",
-                    "required": true,
-                    "description": "Notebook ID",
-                    "label": "Notebook Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "number",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog notebooks",
-            "type": "step.datadog_notebook_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "notebooks",
-                    "type": "array",
-                    "description": "List of notebooks."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List Datadog hosts",
-            "type": "step.datadog_host_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "filter",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter string",
-                    "label": "Filter"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "hosts",
-                    "type": "array",
-                    "description": "List of hosts."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Mute a Datadog host",
-            "type": "step.datadog_host_mute",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "host_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Host name",
-                    "label": "Host Name"
-                },
-                {
-                    "key": "message",
-                    "type": "string",
-                    "required": false,
-                    "description": "Mute message",
-                    "label": "Message"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "hostname",
-                    "type": "string",
-                    "description": "The hostname of the operation result."
-                },
-                {
-                    "key": "action",
-                    "type": "string",
-                    "description": "The action of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Unmute a Datadog host",
-            "type": "step.datadog_host_unmute",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "host_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Host name",
-                    "label": "Host Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "hostname",
-                    "type": "string",
-                    "description": "The hostname of the operation result."
-                },
-                {
-                    "key": "action",
-                    "type": "string",
-                    "description": "The action of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get total host counts",
-            "type": "step.datadog_host_totals_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "total_active",
-                    "type": "number",
-                    "description": "Total number of active hosts."
-                },
-                {
-                    "key": "total_up",
-                    "type": "number",
-                    "description": "Total number of hosts reporting as up."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get tags for a host",
-            "type": "step.datadog_tags_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "host_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Host name",
-                    "label": "Host Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "host",
-                    "type": "string",
-                    "description": "The host of the operation result."
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "description": "List of tags."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update tags for a host",
-            "type": "step.datadog_tags_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "host_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Host name",
-                    "label": "Host Name"
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "required": false,
-                    "description": "Tags to set",
-                    "label": "Tags"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "host",
-                    "type": "string",
-                    "description": "The host of the operation result."
-                },
-                {
-                    "key": "tags",
-                    "type": "array",
-                    "description": "List of tags."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete tags for a host",
-            "type": "step.datadog_tags_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "host_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Host name",
-                    "label": "Host Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "host",
-                    "type": "string",
-                    "description": "The host of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List all tags",
-            "type": "step.datadog_tags_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "tags",
-                    "type": "object",
-                    "description": "List of tags."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create or update a service definition",
-            "type": "step.datadog_service_definition_upsert",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "service_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Service name",
-                    "label": "Service Name"
-                },
-                {
-                    "key": "team",
-                    "type": "string",
-                    "required": false,
-                    "description": "Team name",
-                    "label": "Team"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "upserted",
-                    "type": "boolean",
-                    "description": "The upserted of the operation result."
-                },
-                {
-                    "key": "service_name",
-                    "type": "string",
-                    "description": "The service name of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Get a service definition",
-            "type": "step.datadog_service_definition_get",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "service_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Service name",
-                    "label": "Service Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "service_name",
-                    "type": "string",
-                    "description": "The service name of the operation result."
-                },
-                {
-                    "key": "found",
-                    "type": "boolean",
-                    "description": "The found of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete a service definition",
-            "type": "step.datadog_service_definition_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "service_name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Service name",
-                    "label": "Service Name"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "service_name",
-                    "type": "string",
-                    "description": "The service name of the operation result."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List service definitions",
-            "type": "step.datadog_service_definition_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "services",
-                    "type": "array",
-                    "description": "List of services."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Create an APM retention filter",
-            "type": "step.datadog_apm_retention_filter_create",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Filter name",
-                    "label": "Name"
-                },
-                {
-                    "key": "rate",
-                    "type": "number",
-                    "required": false,
-                    "description": "Retention rate",
-                    "label": "Rate"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "description": "The name of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Update an APM retention filter",
-            "type": "step.datadog_apm_retention_filter_update",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "filter_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Filter ID",
-                    "label": "Filter Id"
-                },
-                {
-                    "key": "name",
-                    "type": "string",
-                    "required": true,
-                    "description": "Filter name",
-                    "label": "Name"
-                },
-                {
-                    "key": "rate",
-                    "type": "number",
-                    "required": false,
-                    "description": "Retention rate",
-                    "label": "Rate"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "updated",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully updated."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Delete an APM retention filter",
-            "type": "step.datadog_apm_retention_filter_delete",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "filter_id",
-                    "type": "string",
-                    "required": true,
-                    "description": "Filter ID",
-                    "label": "Filter Id"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "deleted",
-                    "type": "boolean",
-                    "description": "Whether the resource was successfully deleted."
-                },
-                {
-                    "key": "id",
-                    "type": "string",
-                    "description": "The unique identifier of the resource."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List APM retention filters",
-            "type": "step.datadog_apm_retention_filter_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "filters",
-                    "type": "array",
-                    "description": "The filters of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Search APM spans",
-            "type": "step.datadog_span_search",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Search query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "spans",
-                    "type": "array",
-                    "description": "List of APM spans."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Aggregate APM spans",
-            "type": "step.datadog_span_aggregate",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Aggregation query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "buckets",
-                    "type": "array",
-                    "description": "The buckets of the operation result."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "Search audit logs",
-            "type": "step.datadog_audit_log_search",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Search query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "events",
-                    "type": "array",
-                    "description": "List of events."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        },
-        {
-            "description": "List audit logs",
-            "type": "step.datadog_audit_log_list",
-            "plugin": "workflow-plugin-datadog",
-            "configFields": [
-                {
-                    "key": "module",
-                    "type": "string",
-                    "required": false,
-                    "defaultValue": "datadog",
-                    "description": "Datadog module name",
-                    "label": "Module"
-                },
-                {
-                    "key": "query",
-                    "type": "string",
-                    "required": false,
-                    "description": "Filter query",
-                    "label": "Query"
-                }
-            ],
-            "outputs": [
-                {
-                    "key": "events",
-                    "type": "array",
-                    "description": "List of events."
-                },
-                {
-                    "key": "count",
-                    "type": "number",
-                    "description": "Number of items returned."
-                },
-                {
-                    "key": "error",
-                    "type": "string",
-                    "description": "Error message if the step failed"
-                }
-            ]
-        }
-    ],
-    "capabilities": {
-        "configProvider": false,
-        "moduleTypes": [
-            "datadog.provider"
-        ],
-        "stepTypes": [],
-        "triggerTypes": []
+  "name": "workflow-plugin-datadog",
+  "version": "0.1.3",
+  "description": "Datadog monitoring and observability plugin",
+  "author": "GoCodeAlone",
+  "license": "MIT",
+  "type": "external",
+  "tier": "community",
+  "private": false,
+  "minEngineVersion": "0.51.7",
+  "required_secrets": [
+    {
+      "name": "DATADOG_API_KEY",
+      "sensitive": true,
+      "description": "Datadog API key. Referenced as ${DATADOG_API_KEY} in apiKey.",
+      "prompt": "Datadog API key"
+    },
+    {
+      "name": "DATADOG_APP_KEY",
+      "sensitive": true,
+      "description": "Datadog application key (required alongside the API key). Referenced as ${DATADOG_APP_KEY} in appKey.",
+      "prompt": "Datadog application key"
     }
+  ],
+  "keywords": [
+    "datadog",
+    "monitoring",
+    "observability",
+    "metrics",
+    "logs",
+    "apm"
+  ],
+  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-datadog",
+  "repository": "https://github.com/GoCodeAlone/workflow-plugin-datadog",
+  "moduleTypes": [
+    "datadog.provider"
+  ],
+  "stepTypes": [
+    "step.datadog_metric_submit",
+    "step.datadog_metric_query",
+    "step.datadog_metric_query_scalar",
+    "step.datadog_metric_metadata_get",
+    "step.datadog_metric_metadata_update",
+    "step.datadog_metric_list_active",
+    "step.datadog_metric_tag_config_create",
+    "step.datadog_metric_tag_config_update",
+    "step.datadog_metric_tag_config_delete",
+    "step.datadog_metric_tag_config_list",
+    "step.datadog_event_create",
+    "step.datadog_event_get",
+    "step.datadog_event_list",
+    "step.datadog_event_search",
+    "step.datadog_monitor_create",
+    "step.datadog_monitor_get",
+    "step.datadog_monitor_update",
+    "step.datadog_monitor_delete",
+    "step.datadog_monitor_list",
+    "step.datadog_monitor_search",
+    "step.datadog_monitor_validate",
+    "step.datadog_dashboard_create",
+    "step.datadog_dashboard_get",
+    "step.datadog_dashboard_update",
+    "step.datadog_dashboard_delete",
+    "step.datadog_dashboard_list",
+    "step.datadog_log_submit",
+    "step.datadog_log_search",
+    "step.datadog_log_aggregate",
+    "step.datadog_log_archive_create",
+    "step.datadog_log_archive_list",
+    "step.datadog_log_archive_delete",
+    "step.datadog_log_pipeline_create",
+    "step.datadog_log_pipeline_list",
+    "step.datadog_log_pipeline_delete",
+    "step.datadog_synthetics_test_create",
+    "step.datadog_synthetics_test_get",
+    "step.datadog_synthetics_test_update",
+    "step.datadog_synthetics_test_delete",
+    "step.datadog_synthetics_test_list",
+    "step.datadog_synthetics_test_trigger",
+    "step.datadog_synthetics_results_get",
+    "step.datadog_synthetics_global_var_create",
+    "step.datadog_synthetics_global_var_list",
+    "step.datadog_synthetics_global_var_delete",
+    "step.datadog_slo_create",
+    "step.datadog_slo_get",
+    "step.datadog_slo_update",
+    "step.datadog_slo_delete",
+    "step.datadog_slo_list",
+    "step.datadog_slo_search",
+    "step.datadog_slo_history_get",
+    "step.datadog_downtime_create",
+    "step.datadog_downtime_get",
+    "step.datadog_downtime_update",
+    "step.datadog_downtime_cancel",
+    "step.datadog_downtime_list",
+    "step.datadog_incident_create",
+    "step.datadog_incident_get",
+    "step.datadog_incident_update",
+    "step.datadog_incident_delete",
+    "step.datadog_incident_list",
+    "step.datadog_incident_todo_create",
+    "step.datadog_incident_todo_update",
+    "step.datadog_incident_todo_delete",
+    "step.datadog_security_rule_create",
+    "step.datadog_security_rule_get",
+    "step.datadog_security_rule_update",
+    "step.datadog_security_rule_delete",
+    "step.datadog_security_rule_list",
+    "step.datadog_security_signal_list",
+    "step.datadog_security_signal_state_update",
+    "step.datadog_user_create",
+    "step.datadog_user_get",
+    "step.datadog_user_update",
+    "step.datadog_user_disable",
+    "step.datadog_user_list",
+    "step.datadog_user_invite",
+    "step.datadog_role_create",
+    "step.datadog_role_get",
+    "step.datadog_role_update",
+    "step.datadog_role_delete",
+    "step.datadog_role_list",
+    "step.datadog_role_permission_add",
+    "step.datadog_role_permission_remove",
+    "step.datadog_team_create",
+    "step.datadog_team_get",
+    "step.datadog_team_update",
+    "step.datadog_team_delete",
+    "step.datadog_team_list",
+    "step.datadog_team_member_add",
+    "step.datadog_team_member_remove",
+    "step.datadog_api_key_create",
+    "step.datadog_api_key_get",
+    "step.datadog_api_key_update",
+    "step.datadog_api_key_delete",
+    "step.datadog_api_key_list",
+    "step.datadog_app_key_create",
+    "step.datadog_app_key_list",
+    "step.datadog_app_key_delete",
+    "step.datadog_notebook_create",
+    "step.datadog_notebook_get",
+    "step.datadog_notebook_update",
+    "step.datadog_notebook_delete",
+    "step.datadog_notebook_list",
+    "step.datadog_host_list",
+    "step.datadog_host_mute",
+    "step.datadog_host_unmute",
+    "step.datadog_host_totals_get",
+    "step.datadog_tags_get",
+    "step.datadog_tags_update",
+    "step.datadog_tags_delete",
+    "step.datadog_tags_list",
+    "step.datadog_service_definition_upsert",
+    "step.datadog_service_definition_get",
+    "step.datadog_service_definition_delete",
+    "step.datadog_service_definition_list",
+    "step.datadog_apm_retention_filter_create",
+    "step.datadog_apm_retention_filter_update",
+    "step.datadog_apm_retention_filter_delete",
+    "step.datadog_apm_retention_filter_list",
+    "step.datadog_span_search",
+    "step.datadog_span_aggregate",
+    "step.datadog_audit_log_search",
+    "step.datadog_audit_log_list"
+  ],
+  "triggerTypes": [],
+  "stepSchemas": [
+    {
+      "description": "Submit a metric to Datadog",
+      "type": "step.datadog_metric_submit",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "required": true,
+          "description": "Metric name",
+          "label": "Metric"
+        },
+        {
+          "key": "value",
+          "type": "number",
+          "required": false,
+          "description": "Metric value",
+          "label": "Value"
+        },
+        {
+          "key": "type",
+          "type": "select",
+          "required": false,
+          "options": [
+            "count",
+            "rate",
+            "gauge"
+          ],
+          "description": "Metric type",
+          "label": "Type"
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "required": false,
+          "description": "Tags",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "submitted",
+          "type": "boolean",
+          "description": "Whether the operation was successfully submitted."
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "description": "The metric name."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Query metrics from Datadog",
+      "type": "step.datadog_metric_query",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": true,
+          "description": "Metrics query",
+          "label": "Query"
+        },
+        {
+          "key": "from",
+          "type": "number",
+          "required": false,
+          "description": "Start time (epoch seconds)",
+          "label": "From"
+        },
+        {
+          "key": "to",
+          "type": "number",
+          "required": false,
+          "description": "End time (epoch seconds)",
+          "label": "To"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "series",
+          "type": "array",
+          "description": "Array of metric time series data points."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Query scalar metrics from Datadog",
+      "type": "step.datadog_metric_query_scalar",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": true,
+          "description": "Scalar query",
+          "label": "Query"
+        },
+        {
+          "key": "from",
+          "type": "number",
+          "required": false,
+          "description": "Start time",
+          "label": "From"
+        },
+        {
+          "key": "to",
+          "type": "number",
+          "required": false,
+          "description": "End time",
+          "label": "To"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "queried",
+          "type": "boolean",
+          "description": "Whether the query was successfully executed."
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "description": "The query used."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get metric metadata",
+      "type": "step.datadog_metric_metadata_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "required": true,
+          "description": "Metric name",
+          "label": "Metric"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "type",
+          "type": "string",
+          "description": "The type of the resource."
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "description": "The description of the resource."
+        },
+        {
+          "key": "unit",
+          "type": "string",
+          "description": "The unit of measurement."
+        },
+        {
+          "key": "short_name",
+          "type": "string",
+          "description": "The short name or identifier."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update metric metadata",
+      "type": "step.datadog_metric_metadata_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "required": true,
+          "description": "Metric name",
+          "label": "Metric"
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "required": false,
+          "description": "Description",
+          "label": "Description"
+        },
+        {
+          "key": "unit",
+          "type": "string",
+          "required": false,
+          "description": "Unit",
+          "label": "Unit"
+        },
+        {
+          "key": "type",
+          "type": "string",
+          "required": false,
+          "description": "Type",
+          "label": "Type"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "type",
+          "type": "string",
+          "description": "The type of the resource."
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "description": "The description of the resource."
+        },
+        {
+          "key": "unit",
+          "type": "string",
+          "description": "The unit of measurement."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List active metrics",
+      "type": "step.datadog_metric_list_active",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "from",
+          "type": "number",
+          "required": false,
+          "description": "Start time (epoch seconds)",
+          "label": "From"
+        },
+        {
+          "key": "host",
+          "type": "string",
+          "required": false,
+          "description": "Filter by host",
+          "label": "Host"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "metrics",
+          "type": "array",
+          "description": "The metrics of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create metric tag configuration",
+      "type": "step.datadog_metric_tag_config_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "required": true,
+          "description": "Metric name",
+          "label": "Metric"
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "required": false,
+          "description": "Tags",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "created",
+          "type": "boolean",
+          "description": "Whether the resource was successfully created."
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "description": "The metric name."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update metric tag configuration",
+      "type": "step.datadog_metric_tag_config_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "required": true,
+          "description": "Metric name",
+          "label": "Metric"
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "required": false,
+          "description": "Tags",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "description": "The metric name."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete metric tag configuration",
+      "type": "step.datadog_metric_tag_config_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "required": true,
+          "description": "Metric name",
+          "label": "Metric"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the metric tag configuration was successfully deleted."
+        },
+        {
+          "key": "metric",
+          "type": "string",
+          "description": "The metric name."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List metric tag configurations",
+      "type": "step.datadog_metric_tag_config_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "configurations",
+          "type": "array",
+          "description": "The configurations of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog event",
+      "type": "step.datadog_event_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "required": true,
+          "description": "Event title",
+          "label": "Title"
+        },
+        {
+          "key": "text",
+          "type": "string",
+          "required": false,
+          "description": "Event text",
+          "label": "Text"
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "required": false,
+          "description": "Tags",
+          "label": "Tags"
+        },
+        {
+          "key": "host",
+          "type": "string",
+          "required": false,
+          "description": "Host name",
+          "label": "Host"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "description": "The title of the resource."
+        },
+        {
+          "key": "status",
+          "type": "string",
+          "description": "The current status of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog event",
+      "type": "step.datadog_event_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "event_id",
+          "type": "number",
+          "required": true,
+          "description": "Event ID",
+          "label": "Event Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "found",
+          "type": "boolean",
+          "description": "Whether the event was found."
+        },
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "description": "The title of the resource."
+        },
+        {
+          "key": "text",
+          "type": "string",
+          "description": "The text of the operation result."
+        },
+        {
+          "key": "host",
+          "type": "string",
+          "description": "The host of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog events",
+      "type": "step.datadog_event_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "start",
+          "type": "number",
+          "required": false,
+          "description": "Start time",
+          "label": "Start"
+        },
+        {
+          "key": "end",
+          "type": "number",
+          "required": false,
+          "description": "End time",
+          "label": "End"
+        },
+        {
+          "key": "tags",
+          "type": "string",
+          "required": false,
+          "description": "Filter by tags",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "events",
+          "type": "array",
+          "description": "List of events."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Search Datadog events",
+      "type": "step.datadog_event_search",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "start",
+          "type": "number",
+          "required": false,
+          "description": "Start time",
+          "label": "Start"
+        },
+        {
+          "key": "end",
+          "type": "number",
+          "required": false,
+          "description": "End time",
+          "label": "End"
+        },
+        {
+          "key": "tags",
+          "type": "string",
+          "required": false,
+          "description": "Filter by tags",
+          "label": "Tags"
+        },
+        {
+          "key": "sources",
+          "type": "string",
+          "required": false,
+          "description": "Filter by sources",
+          "label": "Sources"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "events",
+          "type": "array",
+          "description": "List of events."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog monitor",
+      "type": "step.datadog_monitor_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Monitor name",
+          "label": "Name"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": true,
+          "description": "Monitor query",
+          "label": "Query"
+        },
+        {
+          "key": "type",
+          "type": "select",
+          "required": false,
+          "options": [
+            "metric alert",
+            "service check",
+            "event alert",
+            "log alert",
+            "query alert"
+          ],
+          "description": "Monitor type",
+          "label": "Type"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": false,
+          "description": "Notification message",
+          "label": "Message"
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "required": false,
+          "description": "Tags",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog monitor",
+      "type": "step.datadog_monitor_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "monitor_id",
+          "type": "number",
+          "required": true,
+          "description": "Monitor ID",
+          "label": "Monitor Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "description": "The query used."
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "description": "The message content."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog monitor",
+      "type": "step.datadog_monitor_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "monitor_id",
+          "type": "number",
+          "required": true,
+          "description": "Monitor ID",
+          "label": "Monitor Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "Monitor name",
+          "label": "Name"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Monitor query",
+          "label": "Query"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": false,
+          "description": "Notification message",
+          "label": "Message"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog monitor",
+      "type": "step.datadog_monitor_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "monitor_id",
+          "type": "number",
+          "required": true,
+          "description": "Monitor ID",
+          "label": "Monitor Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog monitors",
+      "type": "step.datadog_monitor_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "tags",
+          "type": "string",
+          "required": false,
+          "description": "Filter by tags",
+          "label": "Tags"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "Filter by name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "monitors",
+          "type": "array",
+          "description": "List of monitors."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Search Datadog monitors",
+      "type": "step.datadog_monitor_search",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Search query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "monitors",
+          "type": "array",
+          "description": "List of monitors."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Validate a Datadog monitor query",
+      "type": "step.datadog_monitor_validate",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": true,
+          "description": "Monitor query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "valid",
+          "type": "boolean",
+          "description": "Whether the monitor configuration is valid."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog dashboard",
+      "type": "step.datadog_dashboard_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "required": true,
+          "description": "Dashboard title",
+          "label": "Title"
+        },
+        {
+          "key": "layout_type",
+          "type": "select",
+          "required": false,
+          "options": [
+            "ordered",
+            "free"
+          ],
+          "description": "Layout type",
+          "label": "Layout Type"
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "required": false,
+          "description": "Description",
+          "label": "Description"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "description": "The title of the resource."
+        },
+        {
+          "key": "url",
+          "type": "string",
+          "description": "The URL of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog dashboard",
+      "type": "step.datadog_dashboard_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "dashboard_id",
+          "type": "string",
+          "required": true,
+          "description": "Dashboard ID",
+          "label": "Dashboard Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "description": "The title of the resource."
+        },
+        {
+          "key": "url",
+          "type": "string",
+          "description": "The URL of the resource."
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "description": "The description of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog dashboard",
+      "type": "step.datadog_dashboard_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "dashboard_id",
+          "type": "string",
+          "required": true,
+          "description": "Dashboard ID",
+          "label": "Dashboard Id"
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "required": false,
+          "description": "Dashboard title. Defaults to \"Updated Dashboard\" when not provided.",
+          "label": "Title"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "description": "The title of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog dashboard",
+      "type": "step.datadog_dashboard_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "dashboard_id",
+          "type": "string",
+          "required": true,
+          "description": "Dashboard ID",
+          "label": "Dashboard Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog dashboards",
+      "type": "step.datadog_dashboard_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "dashboards",
+          "type": "array",
+          "description": "List of dashboards."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Submit a log to Datadog",
+      "type": "step.datadog_log_submit",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": true,
+          "description": "Log message",
+          "label": "Message"
+        },
+        {
+          "key": "service",
+          "type": "string",
+          "required": false,
+          "description": "Service name",
+          "label": "Service"
+        },
+        {
+          "key": "source",
+          "type": "string",
+          "required": false,
+          "description": "Log source",
+          "label": "Source"
+        },
+        {
+          "key": "host",
+          "type": "string",
+          "required": false,
+          "description": "Host name",
+          "label": "Host"
+        },
+        {
+          "key": "tags",
+          "type": "string",
+          "required": false,
+          "description": "Tags",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "submitted",
+          "type": "boolean",
+          "description": "Whether the operation was successfully submitted."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Search Datadog logs",
+      "type": "step.datadog_log_search",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Search query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "logs",
+          "type": "array",
+          "description": "List of log entries."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Aggregate Datadog logs",
+      "type": "step.datadog_log_aggregate",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Aggregation query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "buckets",
+          "type": "array",
+          "description": "The buckets of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a log archive",
+      "type": "step.datadog_log_archive_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Archive name",
+          "label": "Name"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Filter query",
+          "label": "Query"
+        },
+        {
+          "key": "bucket",
+          "type": "string",
+          "required": false,
+          "description": "S3 bucket name. Defaults to \"my-bucket\" when not provided, which will fail with a real Datadog API call.",
+          "label": "Bucket"
+        },
+        {
+          "key": "path",
+          "type": "string",
+          "required": false,
+          "description": "Archive path",
+          "label": "Path"
+        },
+        {
+          "key": "role_arn",
+          "type": "string",
+          "required": false,
+          "description": "IAM role name used by the Datadog-AWS S3 integration (not an ARN). Corresponds to the RoleName field in the Datadog API.",
+          "label": "Role Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List log archives",
+      "type": "step.datadog_log_archive_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "archives",
+          "type": "array",
+          "description": "The archives of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a log archive",
+      "type": "step.datadog_log_archive_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "archive_id",
+          "type": "string",
+          "required": true,
+          "description": "Archive ID",
+          "label": "Archive Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a log pipeline",
+      "type": "step.datadog_log_pipeline_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Pipeline name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List log pipelines",
+      "type": "step.datadog_log_pipeline_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "pipelines",
+          "type": "array",
+          "description": "The pipelines of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a log pipeline",
+      "type": "step.datadog_log_pipeline_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "pipeline_id",
+          "type": "string",
+          "required": true,
+          "description": "Pipeline ID",
+          "label": "Pipeline Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a synthetic test",
+      "type": "step.datadog_synthetics_test_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Test name",
+          "label": "Name"
+        },
+        {
+          "key": "url",
+          "type": "string",
+          "required": false,
+          "description": "Test URL. Defaults to \"https://example.com\" when not provided.",
+          "label": "Url"
+        },
+        {
+          "key": "locations",
+          "type": "array",
+          "required": false,
+          "description": "Test locations. Defaults to \"aws:us-east-1\" when not provided.",
+          "label": "Locations"
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "required": false,
+          "description": "Tags",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "public_id",
+          "type": "string",
+          "description": "The public id of the operation result."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a synthetic test",
+      "type": "step.datadog_synthetics_test_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "public_id",
+          "type": "string",
+          "required": true,
+          "description": "Test public ID",
+          "label": "Public Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "public_id",
+          "type": "string",
+          "description": "The public id of the operation result."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a synthetic test",
+      "type": "step.datadog_synthetics_test_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "public_id",
+          "type": "string",
+          "required": true,
+          "description": "Test public ID",
+          "label": "Public Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "Test name",
+          "label": "Name"
+        },
+        {
+          "key": "url",
+          "type": "string",
+          "required": false,
+          "description": "Test URL. Defaults to \"https://example.com\" when not provided, which will overwrite the existing URL.",
+          "label": "Url"
+        },
+        {
+          "key": "locations",
+          "type": "array",
+          "required": false,
+          "description": "Test locations. Defaults to \"aws:us-east-1\" when not provided, which will overwrite the existing locations.",
+          "label": "Locations"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "public_id",
+          "type": "string",
+          "description": "The public id of the operation result."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete synthetic tests",
+      "type": "step.datadog_synthetics_test_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "public_ids",
+          "type": "array",
+          "required": false,
+          "description": "List of public IDs to delete. At least one of public_ids or public_id is required.",
+          "label": "Public Ids"
+        },
+        {
+          "key": "public_id",
+          "type": "string",
+          "required": false,
+          "description": "Single public ID to delete. At least one of public_id or public_ids is required.",
+          "label": "Public Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "array",
+          "description": "List of deleted public IDs."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List synthetic tests",
+      "type": "step.datadog_synthetics_test_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "tests",
+          "type": "array",
+          "description": "List of synthetic tests."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Trigger synthetic tests",
+      "type": "step.datadog_synthetics_test_trigger",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "public_ids",
+          "type": "array",
+          "required": false,
+          "description": "List of public IDs to trigger. At least one of public_ids or public_id is required.",
+          "label": "Public Ids"
+        },
+        {
+          "key": "public_id",
+          "type": "string",
+          "required": false,
+          "description": "Single public ID to trigger. At least one of public_id or public_ids is required.",
+          "label": "Public Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "results",
+          "type": "array",
+          "description": "List of results."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get synthetic test results",
+      "type": "step.datadog_synthetics_results_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "public_id",
+          "type": "string",
+          "required": true,
+          "description": "Test public ID",
+          "label": "Public Id"
+        },
+        {
+          "key": "result_id",
+          "type": "string",
+          "required": true,
+          "description": "Result ID",
+          "label": "Result Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "result_id",
+          "type": "string",
+          "description": "The result id of the operation result."
+        },
+        {
+          "key": "status",
+          "type": "number",
+          "description": "The current status of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a synthetic global variable",
+      "type": "step.datadog_synthetics_global_var_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Variable name",
+          "label": "Name"
+        },
+        {
+          "key": "value",
+          "type": "string",
+          "required": false,
+          "description": "Variable value",
+          "label": "Value"
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "required": false,
+          "description": "Description",
+          "label": "Description"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List synthetic global variables",
+      "type": "step.datadog_synthetics_global_var_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "variables",
+          "type": "array",
+          "description": "The variables of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a synthetic global variable",
+      "type": "step.datadog_synthetics_global_var_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "variable_id",
+          "type": "string",
+          "required": true,
+          "description": "Variable ID",
+          "label": "Variable Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Service Level Objective",
+      "type": "step.datadog_slo_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "SLO name",
+          "label": "Name"
+        },
+        {
+          "key": "type",
+          "type": "select",
+          "required": false,
+          "options": [
+            "metric",
+            "monitor"
+          ],
+          "description": "SLO type",
+          "label": "Type"
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "required": false,
+          "description": "Description",
+          "label": "Description"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Service Level Objective",
+      "type": "step.datadog_slo_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "slo_id",
+          "type": "string",
+          "required": true,
+          "description": "SLO ID",
+          "label": "Slo Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "found",
+          "type": "boolean",
+          "description": "The found of the operation result."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Service Level Objective",
+      "type": "step.datadog_slo_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "slo_id",
+          "type": "string",
+          "required": true,
+          "description": "SLO ID",
+          "label": "Slo Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "SLO name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Service Level Objective",
+      "type": "step.datadog_slo_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "slo_id",
+          "type": "string",
+          "required": true,
+          "description": "SLO ID",
+          "label": "Slo Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Service Level Objectives",
+      "type": "step.datadog_slo_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Filter query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "slos",
+          "type": "array",
+          "description": "List of SLOs."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Search Service Level Objectives",
+      "type": "step.datadog_slo_search",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Search query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "slos",
+          "type": "array",
+          "description": "List of SLOs."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get SLO history",
+      "type": "step.datadog_slo_history_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "slo_id",
+          "type": "string",
+          "required": true,
+          "description": "SLO ID",
+          "label": "Slo Id"
+        },
+        {
+          "key": "from",
+          "type": "number",
+          "required": false,
+          "description": "Start time (epoch seconds)",
+          "label": "From"
+        },
+        {
+          "key": "to",
+          "type": "number",
+          "required": false,
+          "description": "End time (epoch seconds)",
+          "label": "To"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "slo_id",
+          "type": "string",
+          "description": "The slo id of the operation result."
+        },
+        {
+          "key": "from",
+          "type": "number",
+          "description": "The from of the operation result."
+        },
+        {
+          "key": "to",
+          "type": "number",
+          "description": "The to of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog downtime",
+      "type": "step.datadog_downtime_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "scope",
+          "type": "string",
+          "required": false,
+          "description": "Downtime scope",
+          "label": "Scope"
+        },
+        {
+          "key": "start",
+          "type": "number",
+          "required": false,
+          "description": "Start time (epoch seconds)",
+          "label": "Start"
+        },
+        {
+          "key": "end",
+          "type": "number",
+          "required": false,
+          "description": "End time (epoch seconds)",
+          "label": "End"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": false,
+          "description": "Message",
+          "label": "Message"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "scope",
+          "type": "array",
+          "description": "The scope of the operation result."
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "description": "The message content."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog downtime",
+      "type": "step.datadog_downtime_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "downtime_id",
+          "type": "number",
+          "required": true,
+          "description": "Downtime ID",
+          "label": "Downtime Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "scope",
+          "type": "array",
+          "description": "The scope of the operation result."
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "description": "The message content."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog downtime",
+      "type": "step.datadog_downtime_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "downtime_id",
+          "type": "number",
+          "required": true,
+          "description": "Downtime ID",
+          "label": "Downtime Id"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": false,
+          "description": "Message",
+          "label": "Message"
+        },
+        {
+          "key": "scope",
+          "type": "string",
+          "required": false,
+          "description": "Scope",
+          "label": "Scope"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Cancel a Datadog downtime",
+      "type": "step.datadog_downtime_cancel",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "downtime_id",
+          "type": "number",
+          "required": true,
+          "description": "Downtime ID",
+          "label": "Downtime Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "cancelled",
+          "type": "boolean",
+          "description": "The cancelled of the operation result."
+        },
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog downtimes",
+      "type": "step.datadog_downtime_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "current_only",
+          "type": "boolean",
+          "required": false,
+          "description": "Return only current downtimes",
+          "label": "Current Only"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "downtimes",
+          "type": "array",
+          "description": "List of downtimes."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog incident",
+      "type": "step.datadog_incident_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "required": true,
+          "description": "Incident title",
+          "label": "Title"
+        },
+        {
+          "key": "customer_impacted",
+          "type": "boolean",
+          "required": false,
+          "description": "Customer impacted",
+          "label": "Customer Impacted"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "description": "The title of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog incident",
+      "type": "step.datadog_incident_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "incident_id",
+          "type": "string",
+          "required": true,
+          "description": "Incident ID",
+          "label": "Incident Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "description": "The title of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog incident",
+      "type": "step.datadog_incident_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "incident_id",
+          "type": "string",
+          "required": true,
+          "description": "Incident ID",
+          "label": "Incident Id"
+        },
+        {
+          "key": "title",
+          "type": "string",
+          "required": false,
+          "description": "Incident title",
+          "label": "Title"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog incident",
+      "type": "step.datadog_incident_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "incident_id",
+          "type": "string",
+          "required": true,
+          "description": "Incident ID",
+          "label": "Incident Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog incidents",
+      "type": "step.datadog_incident_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "incidents",
+          "type": "array",
+          "description": "List of incidents."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create an incident todo",
+      "type": "step.datadog_incident_todo_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "incident_id",
+          "type": "string",
+          "required": true,
+          "description": "Incident ID",
+          "label": "Incident Id"
+        },
+        {
+          "key": "content",
+          "type": "string",
+          "required": true,
+          "description": "Todo content",
+          "label": "Content"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "incident_id",
+          "type": "string",
+          "description": "The incident id of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update an incident todo",
+      "type": "step.datadog_incident_todo_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "incident_id",
+          "type": "string",
+          "required": true,
+          "description": "Incident ID",
+          "label": "Incident Id"
+        },
+        {
+          "key": "todo_id",
+          "type": "string",
+          "required": true,
+          "description": "Todo ID",
+          "label": "Todo Id"
+        },
+        {
+          "key": "content",
+          "type": "string",
+          "required": false,
+          "description": "Todo content",
+          "label": "Content"
+        },
+        {
+          "key": "completed",
+          "type": "boolean",
+          "required": false,
+          "description": "Set to true to mark the todo as completed. Setting false has no effect.",
+          "label": "Completed"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete an incident todo",
+      "type": "step.datadog_incident_todo_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "incident_id",
+          "type": "string",
+          "required": true,
+          "description": "Incident ID",
+          "label": "Incident Id"
+        },
+        {
+          "key": "todo_id",
+          "type": "string",
+          "required": true,
+          "description": "Todo ID",
+          "label": "Todo Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a security monitoring rule",
+      "type": "step.datadog_security_rule_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Rule name",
+          "label": "Name"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": false,
+          "description": "Rule message",
+          "label": "Message"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a security monitoring rule",
+      "type": "step.datadog_security_rule_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "rule_id",
+          "type": "string",
+          "required": true,
+          "description": "Rule ID",
+          "label": "Rule Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a security monitoring rule",
+      "type": "step.datadog_security_rule_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "rule_id",
+          "type": "string",
+          "required": true,
+          "description": "Rule ID",
+          "label": "Rule Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Rule name",
+          "label": "Name"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": false,
+          "description": "Rule message",
+          "label": "Message"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a security monitoring rule",
+      "type": "step.datadog_security_rule_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "rule_id",
+          "type": "string",
+          "required": true,
+          "description": "Rule ID",
+          "label": "Rule Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List security monitoring rules",
+      "type": "step.datadog_security_rule_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "rules",
+          "type": "array",
+          "description": "List of security rules."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List security signals",
+      "type": "step.datadog_security_signal_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Filter query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "signals",
+          "type": "array",
+          "description": "List of security signals."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update security signal state",
+      "type": "step.datadog_security_signal_state_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "signal_id",
+          "type": "string",
+          "required": true,
+          "description": "Signal ID",
+          "label": "Signal Id"
+        },
+        {
+          "key": "state",
+          "type": "select",
+          "required": false,
+          "options": [
+            "open",
+            "archived",
+            "under_review"
+          ],
+          "description": "Signal state",
+          "label": "State"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "signal_id",
+          "type": "string",
+          "description": "The signal id of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog user",
+      "type": "step.datadog_user_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "email",
+          "type": "string",
+          "required": true,
+          "description": "User email",
+          "label": "Email"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "User name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "email",
+          "type": "string",
+          "description": "The email address."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog user",
+      "type": "step.datadog_user_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "User ID",
+          "label": "User Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "email",
+          "type": "string",
+          "description": "The email address."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog user",
+      "type": "step.datadog_user_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "User ID",
+          "label": "User Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "User name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Disable a Datadog user",
+      "type": "step.datadog_user_disable",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "User ID",
+          "label": "User Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "disabled",
+          "type": "boolean",
+          "description": "The disabled of the operation result."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog users",
+      "type": "step.datadog_user_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "users",
+          "type": "array",
+          "description": "List of users."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Invite a Datadog user",
+      "type": "step.datadog_user_invite",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "User ID",
+          "label": "User Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "invitations",
+          "type": "array",
+          "description": "The invitations of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog role",
+      "type": "step.datadog_role_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Role name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog role",
+      "type": "step.datadog_role_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "role_id",
+          "type": "string",
+          "required": true,
+          "description": "Role ID",
+          "label": "Role Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog role",
+      "type": "step.datadog_role_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "role_id",
+          "type": "string",
+          "required": true,
+          "description": "Role ID",
+          "label": "Role Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Role name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog role",
+      "type": "step.datadog_role_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "role_id",
+          "type": "string",
+          "required": true,
+          "description": "Role ID",
+          "label": "Role Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog roles",
+      "type": "step.datadog_role_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "roles",
+          "type": "array",
+          "description": "List of roles."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Add a permission to a role",
+      "type": "step.datadog_role_permission_add",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "role_id",
+          "type": "string",
+          "required": true,
+          "description": "Role ID",
+          "label": "Role Id"
+        },
+        {
+          "key": "permission_id",
+          "type": "string",
+          "required": true,
+          "description": "Permission ID",
+          "label": "Permission Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "added",
+          "type": "boolean",
+          "description": "The added of the operation result."
+        },
+        {
+          "key": "permission_count",
+          "type": "number",
+          "description": "The permission count of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Remove a permission from a role",
+      "type": "step.datadog_role_permission_remove",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "role_id",
+          "type": "string",
+          "required": true,
+          "description": "Role ID",
+          "label": "Role Id"
+        },
+        {
+          "key": "permission_id",
+          "type": "string",
+          "required": true,
+          "description": "Permission ID",
+          "label": "Permission Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "removed",
+          "type": "boolean",
+          "description": "The removed of the operation result."
+        },
+        {
+          "key": "role_id",
+          "type": "string",
+          "description": "The role id of the operation result."
+        },
+        {
+          "key": "permission_id",
+          "type": "string",
+          "description": "The permission id of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog team",
+      "type": "step.datadog_team_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Team name",
+          "label": "Name"
+        },
+        {
+          "key": "handle",
+          "type": "string",
+          "required": true,
+          "description": "Team handle",
+          "label": "Handle"
+        },
+        {
+          "key": "description",
+          "type": "string",
+          "required": false,
+          "description": "Description",
+          "label": "Description"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "handle",
+          "type": "string",
+          "description": "The team handle."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog team",
+      "type": "step.datadog_team_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "team_id",
+          "type": "string",
+          "required": true,
+          "description": "Team ID",
+          "label": "Team Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog team",
+      "type": "step.datadog_team_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "team_id",
+          "type": "string",
+          "required": true,
+          "description": "Team ID",
+          "label": "Team Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "Team name",
+          "label": "Name"
+        },
+        {
+          "key": "handle",
+          "type": "string",
+          "required": false,
+          "description": "Team handle. Defaults to team_id when not provided, which may overwrite an existing handle.",
+          "label": "Handle"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog team",
+      "type": "step.datadog_team_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "team_id",
+          "type": "string",
+          "required": true,
+          "description": "Team ID",
+          "label": "Team Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog teams",
+      "type": "step.datadog_team_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "teams",
+          "type": "array",
+          "description": "List of teams."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Add a member to a team",
+      "type": "step.datadog_team_member_add",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "team_id",
+          "type": "string",
+          "required": true,
+          "description": "Team ID",
+          "label": "Team Id"
+        },
+        {
+          "key": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "User ID",
+          "label": "User Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "added",
+          "type": "boolean",
+          "description": "The added of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Remove a member from a team",
+      "type": "step.datadog_team_member_remove",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "team_id",
+          "type": "string",
+          "required": true,
+          "description": "Team ID",
+          "label": "Team Id"
+        },
+        {
+          "key": "user_id",
+          "type": "string",
+          "required": true,
+          "description": "User ID",
+          "label": "User Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "removed",
+          "type": "boolean",
+          "description": "The removed of the operation result."
+        },
+        {
+          "key": "team_id",
+          "type": "string",
+          "description": "The team id of the operation result."
+        },
+        {
+          "key": "user_id",
+          "type": "string",
+          "description": "The user id of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog API key",
+      "type": "step.datadog_api_key_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Key name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog API key",
+      "type": "step.datadog_api_key_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "key_id",
+          "type": "string",
+          "required": true,
+          "description": "Key ID",
+          "label": "Key Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog API key",
+      "type": "step.datadog_api_key_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "key_id",
+          "type": "string",
+          "required": true,
+          "description": "Key ID",
+          "label": "Key Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "Key name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog API key",
+      "type": "step.datadog_api_key_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "key_id",
+          "type": "string",
+          "required": true,
+          "description": "Key ID",
+          "label": "Key Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog API keys",
+      "type": "step.datadog_api_key_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "keys",
+          "type": "array",
+          "description": "List of API/application keys."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog application key",
+      "type": "step.datadog_app_key_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Key name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog application keys",
+      "type": "step.datadog_app_key_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "keys",
+          "type": "array",
+          "description": "List of API/application keys."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog application key",
+      "type": "step.datadog_app_key_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "key_id",
+          "type": "string",
+          "required": true,
+          "description": "Key ID",
+          "label": "Key Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create a Datadog notebook",
+      "type": "step.datadog_notebook_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Notebook name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a Datadog notebook",
+      "type": "step.datadog_notebook_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "notebook_id",
+          "type": "number",
+          "required": true,
+          "description": "Notebook ID",
+          "label": "Notebook Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update a Datadog notebook",
+      "type": "step.datadog_notebook_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "notebook_id",
+          "type": "number",
+          "required": true,
+          "description": "Notebook ID",
+          "label": "Notebook Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": false,
+          "description": "Notebook name",
+          "label": "Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a Datadog notebook",
+      "type": "step.datadog_notebook_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "notebook_id",
+          "type": "number",
+          "required": true,
+          "description": "Notebook ID",
+          "label": "Notebook Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "number",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog notebooks",
+      "type": "step.datadog_notebook_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Filter query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "notebooks",
+          "type": "array",
+          "description": "List of notebooks."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List Datadog hosts",
+      "type": "step.datadog_host_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "filter",
+          "type": "string",
+          "required": false,
+          "description": "Filter string",
+          "label": "Filter"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "hosts",
+          "type": "array",
+          "description": "List of hosts."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Mute a Datadog host",
+      "type": "step.datadog_host_mute",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "host_name",
+          "type": "string",
+          "required": true,
+          "description": "Host name",
+          "label": "Host Name"
+        },
+        {
+          "key": "message",
+          "type": "string",
+          "required": false,
+          "description": "Mute message",
+          "label": "Message"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "hostname",
+          "type": "string",
+          "description": "The hostname of the operation result."
+        },
+        {
+          "key": "action",
+          "type": "string",
+          "description": "The action of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Unmute a Datadog host",
+      "type": "step.datadog_host_unmute",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "host_name",
+          "type": "string",
+          "required": true,
+          "description": "Host name",
+          "label": "Host Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "hostname",
+          "type": "string",
+          "description": "The hostname of the operation result."
+        },
+        {
+          "key": "action",
+          "type": "string",
+          "description": "The action of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get total host counts",
+      "type": "step.datadog_host_totals_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "total_active",
+          "type": "number",
+          "description": "Total number of active hosts."
+        },
+        {
+          "key": "total_up",
+          "type": "number",
+          "description": "Total number of hosts reporting as up."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get tags for a host",
+      "type": "step.datadog_tags_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "host_name",
+          "type": "string",
+          "required": true,
+          "description": "Host name",
+          "label": "Host Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "host",
+          "type": "string",
+          "description": "The host of the operation result."
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "description": "List of tags."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update tags for a host",
+      "type": "step.datadog_tags_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "host_name",
+          "type": "string",
+          "required": true,
+          "description": "Host name",
+          "label": "Host Name"
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "required": false,
+          "description": "Tags to set",
+          "label": "Tags"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "host",
+          "type": "string",
+          "description": "The host of the operation result."
+        },
+        {
+          "key": "tags",
+          "type": "array",
+          "description": "List of tags."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete tags for a host",
+      "type": "step.datadog_tags_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "host_name",
+          "type": "string",
+          "required": true,
+          "description": "Host name",
+          "label": "Host Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "host",
+          "type": "string",
+          "description": "The host of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List all tags",
+      "type": "step.datadog_tags_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "tags",
+          "type": "object",
+          "description": "List of tags."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create or update a service definition",
+      "type": "step.datadog_service_definition_upsert",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "service_name",
+          "type": "string",
+          "required": true,
+          "description": "Service name",
+          "label": "Service Name"
+        },
+        {
+          "key": "team",
+          "type": "string",
+          "required": false,
+          "description": "Team name",
+          "label": "Team"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "upserted",
+          "type": "boolean",
+          "description": "The upserted of the operation result."
+        },
+        {
+          "key": "service_name",
+          "type": "string",
+          "description": "The service name of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Get a service definition",
+      "type": "step.datadog_service_definition_get",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "service_name",
+          "type": "string",
+          "required": true,
+          "description": "Service name",
+          "label": "Service Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "service_name",
+          "type": "string",
+          "description": "The service name of the operation result."
+        },
+        {
+          "key": "found",
+          "type": "boolean",
+          "description": "The found of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete a service definition",
+      "type": "step.datadog_service_definition_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "service_name",
+          "type": "string",
+          "required": true,
+          "description": "Service name",
+          "label": "Service Name"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "service_name",
+          "type": "string",
+          "description": "The service name of the operation result."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List service definitions",
+      "type": "step.datadog_service_definition_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "services",
+          "type": "array",
+          "description": "List of services."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Create an APM retention filter",
+      "type": "step.datadog_apm_retention_filter_create",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Filter name",
+          "label": "Name"
+        },
+        {
+          "key": "rate",
+          "type": "number",
+          "required": false,
+          "description": "Retention rate",
+          "label": "Rate"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Filter query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Update an APM retention filter",
+      "type": "step.datadog_apm_retention_filter_update",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "filter_id",
+          "type": "string",
+          "required": true,
+          "description": "Filter ID",
+          "label": "Filter Id"
+        },
+        {
+          "key": "name",
+          "type": "string",
+          "required": true,
+          "description": "Filter name",
+          "label": "Name"
+        },
+        {
+          "key": "rate",
+          "type": "number",
+          "required": false,
+          "description": "Retention rate",
+          "label": "Rate"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Filter query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "updated",
+          "type": "boolean",
+          "description": "Whether the resource was successfully updated."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Delete an APM retention filter",
+      "type": "step.datadog_apm_retention_filter_delete",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "filter_id",
+          "type": "string",
+          "required": true,
+          "description": "Filter ID",
+          "label": "Filter Id"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "deleted",
+          "type": "boolean",
+          "description": "Whether the resource was successfully deleted."
+        },
+        {
+          "key": "id",
+          "type": "string",
+          "description": "The unique identifier of the resource."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List APM retention filters",
+      "type": "step.datadog_apm_retention_filter_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "filters",
+          "type": "array",
+          "description": "The filters of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Search APM spans",
+      "type": "step.datadog_span_search",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Search query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "spans",
+          "type": "array",
+          "description": "List of APM spans."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Aggregate APM spans",
+      "type": "step.datadog_span_aggregate",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Aggregation query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "buckets",
+          "type": "array",
+          "description": "The buckets of the operation result."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "Search audit logs",
+      "type": "step.datadog_audit_log_search",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Search query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "events",
+          "type": "array",
+          "description": "List of events."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    },
+    {
+      "description": "List audit logs",
+      "type": "step.datadog_audit_log_list",
+      "plugin": "workflow-plugin-datadog",
+      "configFields": [
+        {
+          "key": "module",
+          "type": "string",
+          "required": false,
+          "defaultValue": "datadog",
+          "description": "Datadog module name",
+          "label": "Module"
+        },
+        {
+          "key": "query",
+          "type": "string",
+          "required": false,
+          "description": "Filter query",
+          "label": "Query"
+        }
+      ],
+      "outputs": [
+        {
+          "key": "events",
+          "type": "array",
+          "description": "List of events."
+        },
+        {
+          "key": "count",
+          "type": "number",
+          "description": "Number of items returned."
+        },
+        {
+          "key": "error",
+          "type": "string",
+          "description": "Error message if the step failed"
+        }
+      ]
+    }
+  ],
+  "capabilities": {
+    "configProvider": false,
+    "moduleTypes": [
+      "datadog.provider"
+    ],
+    "stepTypes": [],
+    "triggerTypes": []
+  }
 }


### PR DESCRIPTION
Advertise required_secrets[] so 'wfctl secrets setup --plugin datadog' provisions credentials uniformly. Part of the ecosystem sweep (workspace docs/plans/2026-05-31-plugin-required-secrets-sweep*; ADR 0006). No release. Names per design §4. Copilot not requested (down).