### PR TITLE
ci: canonical registry notify (fix dead dispatch + drop manifest-overwrite)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,55 +41,22 @@ jobs:
           GOPRIVATE: github.com/GoCodeAlone/*
           GONOSUMCHECK: github.com/GoCodeAlone/*
 
-  notify-registry:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [goreleaser]
+  notify-workflow-registry:
+    name: Notify workflow-registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: goreleaser
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-datadog'
     steps:
-      # workflow#765: runtime truth-check via plugin verify-capabilities.
-      - name: Verify capabilities (runtime truth-check)
-        run: |
-          RUNNER_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-          BIN=$(jq -r --arg arch "$RUNNER_ARCH" \
-            '[.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$arch and (.name|startswith("workflow-plugin-datadog")))] | .[0].path // ""' \
-            dist/artifacts.json)
-          if [ -z "$BIN" ] || [ "$BIN" = "null" ]; then
-            echo "::warning::No matching linux/$RUNNER_ARCH binary in dist/artifacts.json; skipping verify-capabilities"
-            jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
-            exit 0
-          fi
-          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
-      - name: Notify workflow-registry
-        if: env.GH_TOKEN != ''
-        uses: peter-evans/repository-dispatch@v3
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
-          token: ${{ secrets.REGISTRY_PAT }}
+          token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: >-
-            {"plugin": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}
-        env:
-          GH_TOKEN: ${{ secrets.REGISTRY_PAT }}
-        continue-on-error: true
-      - name: Publish GitHub release
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
-          script: |
-            const tag = context.ref.replace('refs/tags/', '');
-            const { owner, repo } = context.repo;
-            // listReleases returns drafts; getReleaseByTag 404s on drafts. GoReleaser
-            // creates releases as draft; this step flips them to non-draft post-publish.
-            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
-            const release = releases.find(r => r.tag_name === tag);
-            if (!release) {
-              throw new Error(`release for tag ${tag} not found in repo listing (latest 100 releases)`);
-            }
-            if (release.draft) {
-              await github.rest.repos.updateRelease({
-                owner,
-                repo,
-                release_id: release.id,
-                draft: false,
-              });
-            }
+          client-payload: |-
+            {"plugin": "datadog", "tag": "${{ github.ref_name }}"}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,53 @@ jobs:
           GOPRIVATE: github.com/GoCodeAlone/*
           GONOSUMCHECK: github.com/GoCodeAlone/*
 
+  publish-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [goreleaser]
+    runs-on: ubuntu-latest
+    steps:
+      # workflow#765: runtime truth-check via plugin verify-capabilities.
+      - name: Verify capabilities (runtime truth-check)
+        run: |
+          RUNNER_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          BIN=$(jq -r --arg arch "$RUNNER_ARCH" \
+            '[.[] | select(.type=="Binary" and .goos=="linux" and .goarch==$arch and (.name|startswith("workflow-plugin-datadog")))] | .[0].path // ""' \
+            dist/artifacts.json)
+          if [ -z "$BIN" ] || [ "$BIN" = "null" ]; then
+            echo "::warning::No matching linux/$RUNNER_ARCH binary in dist/artifacts.json; skipping verify-capabilities"
+            jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
+            exit 0
+          fi
+          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+      - name: Publish GitHub release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASES_TOKEN || github.token }}
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const { owner, repo } = context.repo;
+            // listReleases returns drafts; getReleaseByTag 404s on drafts. GoReleaser
+            // creates releases as draft; this step flips them to non-draft post-publish.
+            const { data: releases } = await github.rest.repos.listReleases({ owner, repo, per_page: 100 });
+            const release = releases.find(r => r.tag_name === tag);
+            if (!release) {
+              throw new Error(`release for tag ${tag} not found in repo listing (latest 100 releases)`);
+            }
+            if (release.draft) {
+              await github.rest.repos.updateRelease({
+                owner,
+                repo,
+                release_id: release.id,
+                draft: false,
+              });
+            }
+
   notify-workflow-registry:
     name: Notify workflow-registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: goreleaser
+    needs: publish-release
     if: >-
       !github.event.deleted
       && !contains(github.ref_name, '-')


### PR DESCRIPTION
Replace `notify-registry` (used `REGISTRY_PAT`, sent full `github.repository` as plugin name — mismatched registry lookup) with fleet-canonical `notify-workflow-registry`: pinned `peter-evans/repository-dispatch@v4` SHA, `repo_dispatch_token` secret, bare plugin name `"datadog"`, and pre-release guard via `!contains(github.ref_name, '-')`.

No functional change to the goreleaser build job.